### PR TITLE
Improve XML element creation and add tests for special character handling (eq. &)

### DIFF
--- a/src/XlsxFastEditor.php
+++ b/src/XlsxFastEditor.php
@@ -1028,12 +1028,16 @@ final class XlsxFastEditor
 		}
 
 		try {
-			$t = $dom->createElement('t', $value);
+			// First, we create an empty element t
+			$t = $dom->createElement('t');
+			if ($t === false) {
+				throw new XlsxFastEditorXmlException('Failed to create <t> element');
+			}
+			// Add content as a text node
+			$textNode = $dom->createTextNode($value);
+			$t->appendChild($textNode);
 		} catch (\DOMException $dex) {
 			throw new XlsxFastEditorXmlException('Error creating <t> in shared strings!', $dex->code, $dex);
-		}
-		if ($t === false) {
-			throw new XlsxFastEditorXmlException('Error creating <t> in shared strings!');
 		}
 		$si->appendChild($t);
 		if (!($dom->firstElementChild instanceof \DOMElement)) {
@@ -1048,7 +1052,7 @@ final class XlsxFastEditor
 		$dom->firstElementChild->setAttribute('uniqueCount', (string)$uniqueCount);
 
 		$this->touchPath(self::SHARED_STRINGS_PATH);
-		return $uniqueCount - 1;	// Base 0
+		return $uniqueCount - 1; // Base 0
 	}
 
 	/**

--- a/src/XlsxFastEditor.php
+++ b/src/XlsxFastEditor.php
@@ -1052,7 +1052,7 @@ final class XlsxFastEditor
 		$dom->firstElementChild->setAttribute('uniqueCount', (string)$uniqueCount);
 
 		$this->touchPath(self::SHARED_STRINGS_PATH);
-		return $uniqueCount - 1; // Base 0
+		return $uniqueCount - 1;	// Base 0
 	}
 
 	/**

--- a/src/XlsxFastEditor.php
+++ b/src/XlsxFastEditor.php
@@ -1035,6 +1035,9 @@ final class XlsxFastEditor
 			}
 			// Add content as a text node
 			$textNode = $dom->createTextNode($value);
+			if ($textNode === false) {
+				throw new XlsxFastEditorXmlException('Failed to create <t> text node');
+			}
 			$t->appendChild($textNode);
 		} catch (\DOMException $dex) {
 			throw new XlsxFastEditorXmlException('Error creating <t> in shared strings!', $dex->code, $dex);

--- a/src/XlsxFastEditorCell.php
+++ b/src/XlsxFastEditorCell.php
@@ -307,10 +307,17 @@ final class XlsxFastEditorCell
 			throw new XlsxFastEditorXmlException("Internal error accessing cell {$this->name()}!");
 		}
 		try {
-			$f = $dom->createElement('f', $value);
-			if (!($f instanceof \DOMElement)) {
+			// First, we create an empty element t
+			$f = $dom->createElement('f');
+			if ($f === false) {
 				throw new XlsxFastEditorXmlException("Error creating DOMElement of formula for cell {$this->name()}!");
 			}
+			// Add content as a text node
+			$textNode = $dom->createTextNode($value);
+			if ($textNode === false) {
+				throw new XlsxFastEditorXmlException("Error creating text node of formula for cell {$this->name()}!");
+			}
+			$f->appendChild($textNode);
 		} catch (\DOMException $dex) {
 			throw new XlsxFastEditorXmlException("Error creating formula for cell {$this->name()}!", $dex->code, $dex);
 		}

--- a/tests/test.php
+++ b/tests/test.php
@@ -119,6 +119,9 @@ try {
 	$xlsxFastEditor->writeInt($sheet2, 'C3', -7);
 	$xlsxFastEditor->writeFloat($sheet2, 'D3', 273.15);
 
+	// Test writing special character '&'
+	$xlsxFastEditor->writeString($sheet2, 'A5', '&');
+
 	// Writing non-existing cells but existing lines
 	$xlsxFastEditor->writeFormula($sheet2, 'I2', '=7*3');
 	$xlsxFastEditor->writeString($sheet2, 'F2', 'γ');
@@ -165,6 +168,9 @@ try {
 	assert($xlsxFastEditor->readFloat($sheet2, 'D10') === -273.15);
 
 	assert($xlsxFastEditor->readString($sheet1, 'B2') === 'World');
+
+	// Test writing special character '&'
+	assert($xlsxFastEditor->readString($sheet2, 'A5') === '&');
 
 	$xlsxFastEditor->close();
 

--- a/tests/test.php
+++ b/tests/test.php
@@ -119,8 +119,9 @@ try {
 	$xlsxFastEditor->writeInt($sheet2, 'C3', -7);
 	$xlsxFastEditor->writeFloat($sheet2, 'D3', 273.15);
 
-	// Test writing special character '&'
-	$xlsxFastEditor->writeString($sheet2, 'A5', '&');
+	// Writing special XML characters
+	$xlsxFastEditor->writeString($sheet2, 'B5', '< " & \' >');
+	$xlsxFastEditor->writeFormula($sheet2, 'C5', '=LEN("< & \' >")');
 
 	// Writing non-existing cells but existing lines
 	$xlsxFastEditor->writeFormula($sheet2, 'I2', '=7*3');
@@ -169,8 +170,9 @@ try {
 
 	assert($xlsxFastEditor->readString($sheet1, 'B2') === 'World');
 
-	// Test writing special character '&'
-	assert($xlsxFastEditor->readString($sheet2, 'A5') === '&');
+	// Test special XML characters
+	assert($xlsxFastEditor->readString($sheet2, 'B5') === '< " & \' >');
+	assert($xlsxFastEditor->readFormula($sheet2, 'C5') === '=LEN("< & \' >")');
 
 	$xlsxFastEditor->close();
 


### PR DESCRIPTION
Fixes an issue where attempting to write a special character, e.g., "&", to a cell causes the sheet to clear the cell's content upon saving.